### PR TITLE
Feature/label-header resolve #76 CharSeparatedFormatterのエスケープに文字列を指定できるように

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,6 @@
+develop:
+CharSeparatedFormatterのエスケープに文字列を指定できるように機能追加.
+
 1:
 1.5.0: メソッド契約の明示. 機能追加: CharSeparatedFormatterのラベル行にエスケープ文字を追加する機能.
 1.4.0: 内部処理の分岐を修正. 並列性の最適化.

--- a/src/matsu/num/statistics/kerneldensity/output/Kde1dCharSVTextFormatter.java
+++ b/src/matsu/num/statistics/kerneldensity/output/Kde1dCharSVTextFormatter.java
@@ -6,7 +6,7 @@
  */
 
 /*
- * 2026.1.21
+ * 2026.1.27
  */
 package matsu.num.statistics.kerneldensity.output;
 
@@ -33,7 +33,7 @@ import matsu.num.statistics.kerneldensity.KdeGrid1dDto;
  * ({@code <sep>} は区切り文字). <br>
  * ラベル要素は {@code "x"}, {@code "density"} である. <br>
  * データの要素数は必ず 1 以上である ({@code density[0]} が必ず存在する). <br>
- * ラベルエスケープ文字 {@code <escape>} が指定された場合, ラベル行の最初にエスケープ文字が追加される.
+ * ラベルエスケープ文字列 {@code <escape>} が指定された場合, ラベル行の最初にエスケープ文字列が追加される.
  * </p>
  * 
  * @apiNote
@@ -60,7 +60,7 @@ public final class Kde1dCharSVTextFormatter extends Kde1dFormatter<Iterable<Stri
     private final char separator;
 
     private final boolean withLabel;
-    private final Character labelEscape;
+    private final String labelEscape;
 
     /**
      * ラベル無しの Character Separated Values フォーマッターを生成する.
@@ -97,7 +97,7 @@ public final class Kde1dCharSVTextFormatter extends Kde1dFormatter<Iterable<Stri
      * @return Character Separated Values フォーマッター
      */
     public static Kde1dCharSVTextFormatter withLabel(char separator) {
-        return new Kde1dCharSVTextFormatter(separator, null);
+        return withLabelEscaped(separator, "");
     }
 
     /**
@@ -117,7 +117,28 @@ public final class Kde1dCharSVTextFormatter extends Kde1dFormatter<Iterable<Stri
      * @return Character Separated Values フォーマッター
      */
     public static Kde1dCharSVTextFormatter withLabelEscaped(char separator, char labelEscape) {
-        return new Kde1dCharSVTextFormatter(separator, Character.valueOf(labelEscape));
+        return withLabelEscaped(separator, String.valueOf(labelEscape));
+    }
+
+    /**
+     * エスケープ文字列付きラベルを有する, Character Separated Values フォーマッターを生成する.
+     * 
+     * <p>
+     * 文字列形式はクラス説明の通りである.
+     * </p>
+     * 
+     * <p>
+     * 区切り文字, エスケープ文字列に制限はないが,
+     * ほとんどの場合, null文字列 {@code "\u005cu0000"} や改行文字列 {@code "\n"} は不適切である.
+     * </p>
+     * 
+     * @param separator 区切り文字
+     * @param labelEscape ラベル文字列の先頭に付けるエスケープ文字列
+     * @return Character Separated Values フォーマッター
+     * @throws NullPointerException 引数にnullが含まれる場合
+     */
+    public static Kde1dCharSVTextFormatter withLabelEscaped(char separator, String labelEscape) {
+        return new Kde1dCharSVTextFormatter(separator, Objects.requireNonNull(labelEscape));
     }
 
     /**
@@ -128,20 +149,20 @@ public final class Kde1dCharSVTextFormatter extends Kde1dFormatter<Iterable<Stri
     private Kde1dCharSVTextFormatter(char separator) {
         this.separator = separator;
         this.withLabel = false;
-        this.labelEscape = null;
+        this.labelEscape = "";
     }
 
     /**
      * ラベルありのコンストラクタ.
      * 
      * <p>
-     * エスケープしない場合, nullを渡す.
+     * エスケープしない場合, 空文字を渡す.
      * </p>
      * 
      * @param separator 区切り文字
-     * @param labelEscape エスケープ文字, nullを許容
+     * @param labelEscape エスケープ文字
      */
-    private Kde1dCharSVTextFormatter(char separator, Character labelEscape) {
+    private Kde1dCharSVTextFormatter(char separator, String labelEscape) {
         this.separator = separator;
         this.withLabel = true;
         this.labelEscape = labelEscape;
@@ -161,11 +182,7 @@ public final class Kde1dCharSVTextFormatter extends Kde1dFormatter<Iterable<Stri
      * @return "{@literal <escape>}x{@literal <sep>}density"
      */
     private String labelString() {
-        String escape = Objects.isNull(labelEscape)
-                ? ""
-                : String.valueOf(labelEscape.charValue());
-
-        return escape + "x" + Character.toString(separator) + "density";
+        return labelEscape + "x" + Character.toString(separator) + "density";
     }
 
     /**

--- a/src/matsu/num/statistics/kerneldensity/output/Kde2dCharSVTextFormatter.java
+++ b/src/matsu/num/statistics/kerneldensity/output/Kde2dCharSVTextFormatter.java
@@ -6,7 +6,7 @@
  */
 
 /*
- * 2026.1.21
+ * 2026.1.27
  */
 package matsu.num.statistics.kerneldensity.output;
 
@@ -34,7 +34,7 @@ import matsu.num.statistics.kerneldensity.KdeGrid2dDto;
  * イテレーション順は, {@code j} が外側, {@code k} が内側である. <br>
  * ラベル要素は {@code "x"}, {@code "y"}, {@code "density"} である. <br>
  * データの要素数は必ず 1 以上である ({@code density[0][0]} が必ず存在する). <br>
- * ラベルエスケープ文字 {@code <escape>} が指定された場合, ラベル行の最初にエスケープ文字が追加される.
+ * ラベルエスケープ文字列 {@code <escape>} が指定された場合, ラベル行の最初にエスケープ文字列が追加される.
  * </p>
  * 
  * @apiNote
@@ -70,7 +70,7 @@ public final class Kde2dCharSVTextFormatter extends Kde2dFormatter<Iterable<Stri
     private final char separator;
 
     private final boolean withLabel;
-    private final Character labelEscape;
+    private final String labelEscape;
 
     /**
      * ラベル無しの Character Separated Values 文字列出力フォーマッターを生成する.
@@ -107,7 +107,7 @@ public final class Kde2dCharSVTextFormatter extends Kde2dFormatter<Iterable<Stri
      * @return Character Separated Values フォーマッター
      */
     public static Kde2dCharSVTextFormatter withLabel(char separator) {
-        return new Kde2dCharSVTextFormatter(separator, null);
+        return withLabelEscaped(separator, "");
     }
 
     /**
@@ -127,7 +127,28 @@ public final class Kde2dCharSVTextFormatter extends Kde2dFormatter<Iterable<Stri
      * @return Character Separated Values フォーマッター
      */
     public static Kde2dCharSVTextFormatter withLabelEscaped(char separator, char labelEscape) {
-        return new Kde2dCharSVTextFormatter(separator, Character.valueOf(labelEscape));
+        return withLabelEscaped(separator, String.valueOf(labelEscape));
+    }
+
+    /**
+     * エスケープ文字列付きラベルを有する, Character Separated Values フォーマッターを生成する.
+     * 
+     * <p>
+     * 文字列形式はクラス説明の通りである.
+     * </p>
+     * 
+     * <p>
+     * 区切り文字, エスケープ文字列に制限はないが,
+     * ほとんどの場合, null文字列 {@code "\u005cu0000"} や改行文字列 {@code "\n"} は不適切である.
+     * </p>
+     * 
+     * @param separator 区切り文字
+     * @param labelEscape ラベル文字列の先頭に付けるエスケープ文字列
+     * @return Character Separated Values フォーマッター
+     * @throws NullPointerException 引数にnullが含まれる場合
+     */
+    public static Kde2dCharSVTextFormatter withLabelEscaped(char separator, String labelEscape) {
+        return new Kde2dCharSVTextFormatter(separator, Objects.requireNonNull(labelEscape));
     }
 
     /**
@@ -139,20 +160,20 @@ public final class Kde2dCharSVTextFormatter extends Kde2dFormatter<Iterable<Stri
         super();
         this.separator = separator;
         this.withLabel = false;
-        this.labelEscape = null;
+        this.labelEscape = "";
     }
 
     /**
      * ラベルありのコンストラクタ.
      * 
      * <p>
-     * エスケープしない場合, nullを渡す.
+     * エスケープしない場合, 空文字を渡す.
      * </p>
      * 
      * @param separator 区切り文字
-     * @param labelEscape エスケープ文字, nullを許容
+     * @param labelEscape エスケープ文字
      */
-    private Kde2dCharSVTextFormatter(char separator, Character labelEscape) {
+    private Kde2dCharSVTextFormatter(char separator, String labelEscape) {
         super();
         this.separator = separator;
         this.withLabel = true;
@@ -173,11 +194,7 @@ public final class Kde2dCharSVTextFormatter extends Kde2dFormatter<Iterable<Stri
      * @return "{@literal <escape>}x{@literal <sep>}y{@literal <sep>}density"
      */
     private String labelString() {
-        String escape = Objects.isNull(labelEscape)
-                ? ""
-                : String.valueOf(labelEscape.charValue());
-
-        return escape +
+        return labelEscape +
                 "x" + Character.toString(separator) +
                 "y" + Character.toString(separator) +
                 "density";

--- a/test/matsu/num/statistics/kerneldensity/output/Kde1dCharSVTextFormatterTest.java
+++ b/test/matsu/num/statistics/kerneldensity/output/Kde1dCharSVTextFormatterTest.java
@@ -92,12 +92,27 @@ final class Kde1dCharSVTextFormatterTest {
         @Test
         public void test_文字列_ラベルエスケープカンマ区切り() {
             Iterable<String> resultCsv = createTextKdeResult1D()
-                    .formatted(Kde1dCharSVTextFormatter.withLabelEscaped(',','#'));
+                    .formatted(Kde1dCharSVTextFormatter.withLabelEscaped(',', '#'));
 
             String[] resultStr = StreamSupport.stream(resultCsv.spliterator(), false)
                     .toArray(String[]::new);
             String[] expected = {
                     "#x,density",
+                    "1.0,3.0",
+                    "2.0,4.0"
+            };
+            assertThat(resultStr, is(expected));
+        }
+
+        @Test
+        public void test_文字列_ラベルエスケープカンマ区切り_文字列エスケープ() {
+            Iterable<String> resultCsv = createTextKdeResult1D()
+                    .formatted(Kde1dCharSVTextFormatter.withLabelEscaped(',', "//"));
+
+            String[] resultStr = StreamSupport.stream(resultCsv.spliterator(), false)
+                    .toArray(String[]::new);
+            String[] expected = {
+                    "//x,density",
                     "1.0,3.0",
                     "2.0,4.0"
             };

--- a/test/matsu/num/statistics/kerneldensity/output/Kde2dCharSVTextFormatterTest.java
+++ b/test/matsu/num/statistics/kerneldensity/output/Kde2dCharSVTextFormatterTest.java
@@ -101,6 +101,25 @@ final class Kde2dCharSVTextFormatterTest {
         }
 
         @Test
+        public void test_文字列_ラベルエスケープカンマ区切り_文字列エスケープ() {
+            Iterable<String> resultCsv = createTextKdeResult2D()
+                    .formatted(Kde2dCharSVTextFormatter.withLabelEscaped(',', "//"));
+
+            String[] resultStr = StreamSupport.stream(resultCsv.spliterator(), false)
+                    .toArray(String[]::new);
+            String[] expected = {
+                    "//x,y,density",
+                    "1.0,3.0,11.0",
+                    "1.0,4.0,12.0",
+                    "1.0,5.0,13.0",
+                    "2.0,3.0,14.0",
+                    "2.0,4.0,15.0",
+                    "2.0,5.0,16.0"
+            };
+            assertThat(resultStr, is(expected));
+        }
+
+        @Test
         public void test_文字列_ラベルエスケープカンマ区切り() {
             Iterable<String> resultCsv = createTextKdeResult2D()
                     .formatted(Kde2dCharSVTextFormatter.withLabelEscaped(',', '#'));
@@ -202,6 +221,25 @@ final class Kde2dCharSVTextFormatterTest {
                     .toArray(String[]::new);
             String[] expected = {
                     "#x,y,density",
+                    "1.0,4.0,11.0",
+                    "1.0,5.0,12.0",
+                    "2.0,4.0,13.0",
+                    "2.0,5.0,14.0",
+                    "3.0,4.0,15.0",
+                    "3.0,5.0,16.0"
+            };
+            assertThat(resultStr, is(expected));
+        }
+
+        @Test
+        public void test_文字列_ラベルエスケープカンマ区切り_文字列エスケープ() {
+            Iterable<String> resultCsv = createTextKdeResult2D()
+                    .formatted(Kde2dCharSVTextFormatter.withLabelEscaped(',', "//"));
+
+            String[] resultStr = StreamSupport.stream(resultCsv.spliterator(), false)
+                    .toArray(String[]::new);
+            String[] expected = {
+                    "//x,y,density",
                     "1.0,4.0,11.0",
                     "1.0,5.0,12.0",
                     "2.0,4.0,13.0",


### PR DESCRIPTION
for issue #76 
CharSeparatedFormatterのエスケープに文字列を指定できるように